### PR TITLE
탭바, 네비게이션바, 위치 정보 인증 iOS 버젼별 개선

### DIFF
--- a/Escaper/Escaper/Infrastructure/DataMapping/RecordInfoDTO.swift
+++ b/Escaper/Escaper/Infrastructure/DataMapping/RecordInfoDTO.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 struct RecordInfoDTO: Codable {
     var userEmail: String
     var roomId: String

--- a/Escaper/Escaper/Presentation/Common/MainTabBarController.swift
+++ b/Escaper/Escaper/Presentation/Common/MainTabBarController.swift
@@ -46,7 +46,15 @@ private extension MainTabBarController {
         let homeViewController = RoomListViewController()
         homeViewController.tabBarItem = homeBarItem
         homeViewController.create()
-
+        let homeNavigationController = UINavigationController(rootViewController: homeViewController)
+        let navigationAppearance: UINavigationBarAppearance = {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = EDSColor.gloomyBrown.value
+            return appearance
+        }()
+        homeViewController.navigationController?.navigationBar.standardAppearance = navigationAppearance
+        homeViewController.navigationController?.navigationBar.tintColor = EDSColor.skullLightWhite.value
+        homeViewController.navigationController?.navigationBar.barTintColor = EDSColor.skullLightWhite.value
         let recordBarItem = self.makeTabBarItem(
             title: TabBarItemConfig.record.title,
             unselected: TabBarItemConfig.record.unselectedImage,
@@ -55,7 +63,6 @@ private extension MainTabBarController {
         let recordViewController = RecordViewController()
         recordViewController.tabBarItem = recordBarItem
         recordViewController.create()
-
         let mapBarItem = self.makeTabBarItem(
             title: TabBarItemConfig.map.title,
             unselected: TabBarItemConfig.map.unselectedImage,
@@ -64,7 +71,6 @@ private extension MainTabBarController {
         let mapViewController = MapViewController()
         mapViewController.tabBarItem = mapBarItem
         mapViewController.create()
-
         let leaderBoardBarItem = self.makeTabBarItem(
             title: TabBarItemConfig.leaderBoard.title,
             unselected: TabBarItemConfig.leaderBoard.unselectedImage,
@@ -73,9 +79,8 @@ private extension MainTabBarController {
         let leaderBoardViewController = LeaderBoardViewController()
         leaderBoardViewController.tabBarItem = leaderBoardBarItem
         leaderBoardViewController.create()
-
         let viewControllers = [
-            UINavigationController(rootViewController: homeViewController),
+            homeNavigationController,
             recordViewController,
             mapViewController,
             leaderBoardViewController
@@ -84,9 +89,14 @@ private extension MainTabBarController {
     }
 
     func configureSubViewControllers() {
-        self.tabBar.backgroundColor = EDSKit.Color.gloomyBrown.value
-        self.tabBar.tintColor = EDSKit.Color.skullLightWhite.value
-        self.tabBar.barTintColor = EDSKit.Color.skullLightWhite.value
+        let tabBarAppearance: UITabBarAppearance = {
+            let appearance = UITabBarAppearance()
+            appearance.backgroundColor = EDSColor.gloomyBrown.value
+            return appearance
+        }()
+        self.tabBar.standardAppearance = tabBarAppearance
+        self.tabBar.tintColor = EDSColor.skullLightWhite.value
+        self.tabBar.barTintColor = EDSColor.skullLightWhite.value
     }
 
     func makeTabBarItem(title: String, unselected: UIImage?, selected: UIImage?) -> UITabBarItem {

--- a/Escaper/Escaper/Presentation/Common/MainTabBarController.swift
+++ b/Escaper/Escaper/Presentation/Common/MainTabBarController.swift
@@ -55,6 +55,10 @@ private extension MainTabBarController {
         homeViewController.navigationController?.navigationBar.standardAppearance = navigationAppearance
         homeViewController.navigationController?.navigationBar.tintColor = EDSColor.skullLightWhite.value
         homeViewController.navigationController?.navigationBar.barTintColor = EDSColor.skullLightWhite.value
+        if #available(iOS 15.0, *) {
+            homeViewController.navigationController?.navigationBar.compactScrollEdgeAppearance = navigationAppearance
+            homeViewController.navigationController?.navigationBar.scrollEdgeAppearance = navigationAppearance
+        }
         let recordBarItem = self.makeTabBarItem(
             title: TabBarItemConfig.record.title,
             unselected: TabBarItemConfig.record.unselectedImage,

--- a/Escaper/Escaper/Presentation/RoomDetail/RoomDetailViewController.swift
+++ b/Escaper/Escaper/Presentation/RoomDetail/RoomDetailViewController.swift
@@ -47,6 +47,12 @@ final class RoomDetailViewController: DefaultViewController {
         self.roomDetailInfoVeiw.update(room: room)
         self.updateStackView(userRecords: room.userRecords)
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.navigationBar.isHidden = false
+        self.tabBarController?.tabBar.isHidden = true
+    }
 }
 
 private extension RoomDetailViewController {
@@ -64,10 +70,10 @@ private extension RoomDetailViewController {
         self.scrollView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.scrollView)
         NSLayoutConstraint.activate([
-            self.scrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
-            self.scrollView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
-            self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-            self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
+            self.scrollView.frameLayoutGuide.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+            self.scrollView.frameLayoutGuide.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
+            self.scrollView.frameLayoutGuide.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            self.scrollView.frameLayoutGuide.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
         ])
     }
 

--- a/Escaper/Escaper/Presentation/RoomDetail/RoomDetailViewController.swift
+++ b/Escaper/Escaper/Presentation/RoomDetail/RoomDetailViewController.swift
@@ -82,7 +82,7 @@ private extension RoomDetailViewController {
         self.scrollView.addSubview(self.genreImageView)
         NSLayoutConstraint.activate([
             self.genreImageView.centerXAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.centerXAnchor),
-            self.genreImageView.topAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.topAnchor, constant: 64),
+            self.genreImageView.topAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.topAnchor, constant: 32),
             self.genreImageView.widthAnchor.constraint(equalToConstant: Constant.genreImageSize),
             self.genreImageView.heightAnchor.constraint(equalToConstant: Constant.genreImageSize)
         ])

--- a/Escaper/Escaper/Presentation/RoomList/RoomListViewController.swift
+++ b/Escaper/Escaper/Presentation/RoomList/RoomListViewController.swift
@@ -54,6 +54,12 @@ final class RoomListViewController: DefaultViewController {
         self.bindViewModel()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.tabBarController?.tabBar.isHidden = false
+        self.navigationController?.navigationBar.isHidden = true
+    }
+
     func create() {
         let repository = RoomListRepository(service: FirebaseService.shared)
         let usecase = RoomListUseCase(repository: repository)

--- a/Escaper/Escaper/Presentation/RoomList/RoomListViewController.swift
+++ b/Escaper/Escaper/Presentation/RoomList/RoomListViewController.swift
@@ -235,8 +235,6 @@ private extension RoomListViewController {
         if #available(iOS 14.0, *) {
             return
         } else {
-            let manager = CLLocationManager()
-            manager.requestWhenInUseAuthorization()
             let status = CLLocationManager.authorizationStatus()
             switch status {
             case .authorizedAlways, .authorizedWhenInUse, .authorized:


### PR DESCRIPTION
issue number : [#89 ](../issues/89)
close #89

## 작업
탭바, 네비게이션바 iOS 13,14 와 15가 backgroud.color가 다름.
``` swift
let navigationAppearance: UINavigationBarAppearance = {
            let appearance = UINavigationBarAppearance()
            appearance.backgroundColor = EDSColor.gloomyBrown.value
            return appearance
        }()
```
Appearance를 사용해서 개선

### 네비게이션바 iOS15에서 스크롤 시 backgroud.color가 변경됨
``` swift
if #available(iOS 15.0, *) {
            homeViewController.navigationController?.navigationBar.compactScrollEdgeAppearance = navigationAppearance
            homeViewController.navigationController?.navigationBar.scrollEdgeAppearance = navigationAppearance
        }
```

### iOS13에서 첫 접속시 delegate 함수를 진행하지 않음
->iOS14 이전 버젼에 대해서만 함수 실행.