### PR TITLE
[E1 S1 T2, E1 S2 T5] 로그인 & 회원가입 화면의 레이아웃 수정 및 텍스트필드 관련 동작 개선

### DIFF
--- a/Escaper/Escaper/Common/Library/EDSKit.swift
+++ b/Escaper/Escaper/Common/Library/EDSKit.swift
@@ -110,10 +110,12 @@ enum EDSKit {
 
     enum Image {
         case chevronDown
+        case comedyPreview
         case crown
         case distanceIcon
         case emailIcon
         case eyeIcon
+        case fearPreview
         case genreIcon
         case keyMarker
         case loginPumpkin
@@ -123,6 +125,7 @@ enum EDSKit {
         case recordBook
         case recordCard
         case recordCandle
+        case romancePreview
         case signupGhost
         case signupPlus
         case signupSkull

--- a/Escaper/Escaper/Presentation/Login/LoginViewController.swift
+++ b/Escaper/Escaper/Presentation/Login/LoginViewController.swift
@@ -14,6 +14,7 @@ protocol LoginViewControllerDelegate: AnyObject {
 class LoginViewController: DefaultViewController {
     enum Constant {
         static let shortVerticalSpace = CGFloat(20)
+        static let middleVerticalSpace = CGFloat(40)
         static let longVerticalSpace = CGFloat(75)
         static let defaultSpace = CGFloat(15)
         static let loginButtonHeight = CGFloat(50)
@@ -177,7 +178,7 @@ extension LoginViewController {
         self.emailInputView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.emailInputView)
         NSLayoutConstraint.activate([
-            self.emailInputView.topAnchor.constraint(equalTo: self.loginLabel.bottomAnchor, constant: Constant.longVerticalSpace),
+            self.emailInputView.topAnchor.constraint(equalTo: self.loginLabel.bottomAnchor, constant: Constant.middleVerticalSpace),
             self.emailInputView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
             self.emailInputView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.inputViewWidthRatio),
             self.emailInputView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: Constant.inputViewHeightRatio)

--- a/Escaper/Escaper/Presentation/Login/LoginViewController.swift
+++ b/Escaper/Escaper/Presentation/Login/LoginViewController.swift
@@ -136,7 +136,6 @@ extension LoginViewController: UITextFieldDelegate {
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         if textField == self.passwordInputView.textField {
             UIView.animate(withDuration: 0.2, animations: {
-                self.view.frame.origin = CGPoint(x: 0, y: 0)
                 self.view.transform = CGAffineTransform(translationX: 0, y: -self.emailInputView.frame.height)
             })
         }

--- a/Escaper/Escaper/Presentation/Login/LoginViewController.swift
+++ b/Escaper/Escaper/Presentation/Login/LoginViewController.swift
@@ -13,15 +13,13 @@ protocol LoginViewControllerDelegate: AnyObject {
 
 class LoginViewController: DefaultViewController {
     enum Constant {
-        static let shortHorizontalSpace = CGFloat(30)
-        static let middleHorizontalSpace = CGFloat(60)
-        static let longHorizontalSpace = CGFloat(90)
         static let shortVerticalSpace = CGFloat(20)
-        static let middleVerticalSpace = CGFloat(60)
         static let longVerticalSpace = CGFloat(75)
-        static let textFieldHeight = CGFloat(60)
         static let defaultSpace = CGFloat(15)
-        static let loginButtonHeight = CGFloat(45)
+        static let loginButtonHeight = CGFloat(50)
+        static let inputViewWidthRatio = CGFloat(0.8)
+        static let inputViewHeightRatio = CGFloat(0.1)
+        static let middleWidthRatio = CGFloat(0.6)
     }
 
     private weak var delegate: LoginViewControllerDelegate?
@@ -76,7 +74,7 @@ class LoginViewController: DefaultViewController {
         button.setTitle("로그인", for: .normal)
         button.setTitleColor(EDSColor.bloodyBlack.value, for: .normal)
         button.backgroundColor = EDSColor.pumpkin.value
-        button.layer.cornerRadius = CGFloat(20)
+        button.layer.cornerRadius = CGFloat(15)
         button.layer.masksToBounds = true
         return button
     }()
@@ -160,8 +158,8 @@ extension LoginViewController {
         self.view.addSubview(self.pumpkinImageView)
         NSLayoutConstraint.activate([
             self.pumpkinImageView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: Constant.longVerticalSpace),
-            self.pumpkinImageView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.longHorizontalSpace),
-            self.pumpkinImageView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.longHorizontalSpace),
+            self.pumpkinImageView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.pumpkinImageView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.middleWidthRatio),
             self.pumpkinImageView.heightAnchor.constraint(equalTo: self.pumpkinImageView.widthAnchor, multiplier: 0.9)
         ])
     }
@@ -171,8 +169,7 @@ extension LoginViewController {
         self.view.addSubview(self.loginLabel)
         NSLayoutConstraint.activate([
             self.loginLabel.topAnchor.constraint(equalTo: self.pumpkinImageView.bottomAnchor, constant: Constant.shortVerticalSpace),
-            self.loginLabel.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.longHorizontalSpace),
-            self.loginLabel.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.longHorizontalSpace)
+            self.loginLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
         ])
     }
 
@@ -181,9 +178,9 @@ extension LoginViewController {
         self.view.addSubview(self.emailInputView)
         NSLayoutConstraint.activate([
             self.emailInputView.topAnchor.constraint(equalTo: self.loginLabel.bottomAnchor, constant: Constant.longVerticalSpace),
-            self.emailInputView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.shortHorizontalSpace),
-            self.emailInputView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.shortHorizontalSpace),
-            self.emailInputView.heightAnchor.constraint(equalToConstant: Constant.textFieldHeight)
+            self.emailInputView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.emailInputView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.inputViewWidthRatio),
+            self.emailInputView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: Constant.inputViewHeightRatio)
         ])
     }
 
@@ -191,10 +188,10 @@ extension LoginViewController {
         self.passwordInputView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.passwordInputView)
         NSLayoutConstraint.activate([
-            self.passwordInputView.topAnchor.constraint(equalTo: self.emailInputView.bottomAnchor, constant: Constant.shortVerticalSpace),
-            self.passwordInputView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.shortHorizontalSpace),
-            self.passwordInputView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.shortHorizontalSpace),
-            self.passwordInputView.heightAnchor.constraint(equalToConstant: Constant.textFieldHeight)
+            self.passwordInputView.topAnchor.constraint(equalTo: self.emailInputView.bottomAnchor),
+            self.passwordInputView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.passwordInputView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.inputViewWidthRatio),
+            self.passwordInputView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: Constant.inputViewHeightRatio)
         ])
     }
 
@@ -202,9 +199,9 @@ extension LoginViewController {
         self.loginButton.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.loginButton)
         NSLayoutConstraint.activate([
-            self.loginButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -Constant.middleVerticalSpace),
-            self.loginButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.longHorizontalSpace),
-            self.loginButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.longHorizontalSpace),
+            self.loginButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -100),
+            self.loginButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.loginButton.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.middleWidthRatio),
             self.loginButton.heightAnchor.constraint(equalToConstant: Constant.loginButtonHeight)
         ])
     }

--- a/Escaper/Escaper/Presentation/Login/LoginViewController.swift
+++ b/Escaper/Escaper/Presentation/Login/LoginViewController.swift
@@ -119,12 +119,43 @@ class LoginViewController: DefaultViewController {
             self.loginButton.isEnabled = false
         }
     }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        self.view.endEditing(true)
+        self.view.frame.origin = CGPoint(x: 0, y: 0)
+    }
 }
 
 extension LoginViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         self.viewModel?.startEditing()
         self.designateSignupButtonState()
+    }
+
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        if textField == self.passwordInputView.textField {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.view.frame.origin = CGPoint(x: 0, y: 0)
+                self.view.transform = CGAffineTransform(translationX: 0, y: -self.emailInputView.frame.height)
+            })
+        }
+        return true
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        switch textField {
+        case self.emailInputView.textField:
+            self.passwordInputView.textField?.becomeFirstResponder()
+        case self.passwordInputView.textField:
+            textField.endEditing(true)
+            UIView.animate(withDuration: 0.2, animations: {
+                self.view.frame.origin = CGPoint(x: 0, y: 0)
+            })
+        default:
+            break
+        }
+        return true
     }
 }
 
@@ -200,7 +231,7 @@ extension LoginViewController {
         self.loginButton.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.loginButton)
         NSLayoutConstraint.activate([
-            self.loginButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -100),
+            self.loginButton.topAnchor.constraint(equalTo: self.passwordInputView.bottomAnchor, constant: Constant.shortVerticalSpace),
             self.loginButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
             self.loginButton.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.middleWidthRatio),
             self.loginButton.heightAnchor.constraint(equalToConstant: Constant.loginButtonHeight)

--- a/Escaper/Escaper/Presentation/Login/SignUpViewController.swift
+++ b/Escaper/Escaper/Presentation/Login/SignUpViewController.swift
@@ -373,7 +373,7 @@ extension SignUpViewController {
         self.signupButton.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.signupButton)
         NSLayoutConstraint.activate([
-            self.signupButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -100),
+            self.signupButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -70),
             self.signupButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
             self.signupButton.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.middleWidthRatio),
             self.signupButton.heightAnchor.constraint(equalToConstant: Constant.signupButtonHeight)

--- a/Escaper/Escaper/Presentation/Login/SignUpViewController.swift
+++ b/Escaper/Escaper/Presentation/Login/SignUpViewController.swift
@@ -13,15 +13,13 @@ protocol SignUpViewControllerDelegate: AnyObject {
 
 class SignUpViewController: DefaultViewController {
     enum Constant {
-        static let shortHorizontalSpace = CGFloat(30)
-        static let middleHorizontalSpace = CGFloat(60)
-        static let longHorizontalSpace = CGFloat(110)
-        static let shortVerticalSpace = CGFloat(20)
-        static let middleVerticalSpace = CGFloat(60)
-        static let longVerticalSpace = CGFloat(75)
-        static let textFieldHeight = CGFloat(60)
+        static let middleVerticalSpace = CGFloat(40)
+        static let signupButtonHeight = CGFloat(50)
         static let defaultSpace = CGFloat(15)
-        static let signupButtonHeight = CGFloat(45)
+        static let loginButtonHeight = CGFloat(50)
+        static let inputViewWidthRatio = CGFloat(0.8)
+        static let inputViewHeightRatio = CGFloat(0.1)
+        static let middleWidthRatio = CGFloat(0.6)
     }
 
     private weak var delegate: SignUpViewControllerDelegate?
@@ -84,28 +82,28 @@ class SignUpViewController: DefaultViewController {
     }()
     private var pumpkinImageButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(named: "loginPumpkin"), for: .normal)
+        button.setImage(EDSImage.loginPumpkin.value, for: .normal)
         button.layer.cornerRadius = 15
         button.layer.borderColor = EDSColor.pumpkin.value?.cgColor
         return button
     }()
     private var ghostImageButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(named: "signupGhost"), for: .normal)
+        button.setImage(EDSImage.signupGhost.value, for: .normal)
         button.layer.cornerRadius = 15
         button.layer.borderColor = EDSColor.pumpkin.value?.cgColor
         return button
     }()
     private var skullImageButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(named: "signupSkull"), for: .normal)
+        button.setImage(EDSImage.signupSkull.value, for: .normal)
         button.layer.cornerRadius = 15
         button.layer.borderColor = EDSColor.pumpkin.value?.cgColor
         return button
     }()
     private var addImageButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(named: "signupPlus"), for: .normal)
+        button.setImage(EDSImage.signupPlus.value, for: .normal)
         button.layer.cornerRadius = 15
         button.layer.borderColor = EDSColor.pumpkin.value?.cgColor
         return button
@@ -117,7 +115,7 @@ class SignUpViewController: DefaultViewController {
         let button = UIButton()
         button.setTitle("회원가입", for: .normal)
         button.setTitleColor(EDSColor.skullLightWhite.value, for: .normal)
-        button.layer.cornerRadius = CGFloat(20)
+        button.layer.cornerRadius = CGFloat(15)
         button.layer.masksToBounds = true
         button.backgroundColor = EDSColor.gloomyPurple.value
         button.isEnabled = false
@@ -159,7 +157,8 @@ class SignUpViewController: DefaultViewController {
     @objc func signupButtonTapped() {
         guard let email = self.emailInputView.textField?.text,
               let password = self.passwordInputView.textField?.text else { return }
-        ImageCacheManager.shared.uploadUser(image: self.imageView.image, userEmail: email) { result in
+
+        ImageCacheManager.shared.uploadUser(image: userImage(), userEmail: email) { result in
             switch result {
             case .success(let urlString):
                 self.viewModel?.queryUser(email: email) { isExist in
@@ -186,6 +185,24 @@ class SignUpViewController: DefaultViewController {
             self.signupButton.backgroundColor = EDSColor.gloomyPurple.value
             self.signupButton.isEnabled = false
         }
+    }
+
+    func userImage() -> UIImage {
+        var userImage: UIImage?
+        switch self.imageView.image {
+        case EDSImage.loginPumpkin.value:
+            userImage = EDSImage.comedyPreview.value
+        case EDSImage.signupGhost.value:
+            userImage = EDSImage.romancePreview.value
+        case EDSImage.signupSkull.value:
+            userImage = EDSImage.fearPreview.value
+        case EDSImage.signupPlus.value:
+            userImage = imageView.image
+        default:
+            break
+        }
+        guard let image = userImage else { return UIImage() }
+        return image
     }
 }
 
@@ -280,8 +297,8 @@ extension SignUpViewController {
         self.view.addSubview(self.imageView)
         NSLayoutConstraint.activate([
             self.imageView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: Constant.middleVerticalSpace),
-            self.imageView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.longHorizontalSpace),
-            self.imageView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.longHorizontalSpace),
+            self.imageView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.imageView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 0.45),
             self.imageView.heightAnchor.constraint(equalTo: self.imageView.widthAnchor)
         ])
     }
@@ -290,9 +307,8 @@ extension SignUpViewController {
         self.signupLabel.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.signupLabel)
         NSLayoutConstraint.activate([
-            self.signupLabel.topAnchor.constraint(equalTo: self.imageView.bottomAnchor, constant: Constant.shortVerticalSpace),
-            self.signupLabel.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.longHorizontalSpace),
-            self.signupLabel.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.longHorizontalSpace)
+            self.signupLabel.topAnchor.constraint(equalTo: self.imageView.bottomAnchor),
+            self.signupLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
         ])
     }
 
@@ -300,10 +316,10 @@ extension SignUpViewController {
         self.imageStackView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.imageStackView)
         NSLayoutConstraint.activate([
-            self.imageStackView.topAnchor.constraint(equalTo: self.signupLabel.bottomAnchor, constant: Constant.shortVerticalSpace),
-            self.imageStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.middleHorizontalSpace),
-            self.imageStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.middleHorizontalSpace),
-            self.imageStackView.heightAnchor.constraint(equalToConstant: Constant.textFieldHeight)
+            self.imageStackView.topAnchor.constraint(equalTo: self.signupLabel.bottomAnchor, constant: Constant.middleVerticalSpace),
+            self.imageStackView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.imageStackView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.08),
+            self.imageStackView.widthAnchor.constraint(equalTo: self.imageStackView.heightAnchor, multiplier: 4, constant: 45)
         ])
     }
 
@@ -324,10 +340,10 @@ extension SignUpViewController {
         self.emailInputView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.emailInputView)
         NSLayoutConstraint.activate([
-            self.emailInputView.topAnchor.constraint(equalTo: self.imageStackView.bottomAnchor, constant: Constant.longVerticalSpace),
-            self.emailInputView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.shortHorizontalSpace),
-            self.emailInputView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.shortHorizontalSpace),
-            self.emailInputView.heightAnchor.constraint(equalToConstant: Constant.textFieldHeight)
+            self.emailInputView.topAnchor.constraint(equalTo: self.imageStackView.bottomAnchor, constant: Constant.middleVerticalSpace),
+            self.emailInputView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.emailInputView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: Constant.inputViewHeightRatio),
+            self.emailInputView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.inputViewWidthRatio)
         ])
     }
 
@@ -335,10 +351,10 @@ extension SignUpViewController {
         self.passwordInputView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.passwordInputView)
         NSLayoutConstraint.activate([
-            self.passwordInputView.topAnchor.constraint(equalTo: self.emailInputView.bottomAnchor, constant: Constant.shortVerticalSpace),
-            self.passwordInputView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.shortHorizontalSpace),
-            self.passwordInputView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.shortHorizontalSpace),
-            self.passwordInputView.heightAnchor.constraint(equalToConstant: Constant.textFieldHeight)
+            self.passwordInputView.topAnchor.constraint(equalTo: self.emailInputView.bottomAnchor),
+            self.passwordInputView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.passwordInputView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: Constant.inputViewHeightRatio),
+            self.passwordInputView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.inputViewWidthRatio)
         ])
     }
 
@@ -346,10 +362,10 @@ extension SignUpViewController {
         self.passwordCheckInputView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.passwordCheckInputView)
         NSLayoutConstraint.activate([
-            self.passwordCheckInputView.topAnchor.constraint(equalTo: self.passwordInputView.bottomAnchor, constant: Constant.shortVerticalSpace),
-            self.passwordCheckInputView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.shortHorizontalSpace),
-            self.passwordCheckInputView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.shortHorizontalSpace),
-            self.passwordCheckInputView.heightAnchor.constraint(equalToConstant: Constant.textFieldHeight)
+            self.passwordCheckInputView.topAnchor.constraint(equalTo: self.passwordInputView.bottomAnchor),
+            self.passwordCheckInputView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.passwordCheckInputView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: Constant.inputViewHeightRatio),
+            self.passwordCheckInputView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.inputViewWidthRatio)
         ])
     }
 
@@ -357,9 +373,9 @@ extension SignUpViewController {
         self.signupButton.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.signupButton)
         NSLayoutConstraint.activate([
-            self.signupButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -Constant.longVerticalSpace),
-            self.signupButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: Constant.longHorizontalSpace),
-            self.signupButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -Constant.longHorizontalSpace),
+            self.signupButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -100),
+            self.signupButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.signupButton.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.middleWidthRatio),
             self.signupButton.heightAnchor.constraint(equalToConstant: Constant.signupButtonHeight)
         ])
     }

--- a/Escaper/Escaper/Presentation/Login/SignUpViewController.swift
+++ b/Escaper/Escaper/Presentation/Login/SignUpViewController.swift
@@ -13,6 +13,7 @@ protocol SignUpViewControllerDelegate: AnyObject {
 
 class SignUpViewController: DefaultViewController {
     enum Constant {
+        static let shortVerticalSpace = CGFloat(20)
         static let middleVerticalSpace = CGFloat(40)
         static let signupButtonHeight = CGFloat(50)
         static let defaultSpace = CGFloat(15)
@@ -204,6 +205,12 @@ class SignUpViewController: DefaultViewController {
         guard let image = userImage else { return UIImage() }
         return image
     }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        self.view.endEditing(true)
+        self.view.frame.origin = CGPoint(x: 0, y: 0)
+    }
 }
 
 extension SignUpViewController: UIImagePickerControllerDelegate & UINavigationControllerDelegate {
@@ -232,6 +239,41 @@ extension SignUpViewController: UITextFieldDelegate {
             break
         }
         self.designateSignupButtonState()
+    }
+
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        switch textField {
+        case self.passwordInputView.textField:
+            UIView.animate(withDuration: 0.2, animations: {
+                self.view.frame.origin = CGPoint(x: 0, y: 0)
+                self.view.transform = CGAffineTransform(translationX: 0, y: -self.passwordInputView.frame.height*0.5)
+            })
+        case self.passwordCheckInputView.textField:
+            UIView.animate(withDuration: 0.2, animations: {
+                self.view.frame.origin = CGPoint(x: 0, y: 0)
+                self.view.transform = CGAffineTransform(translationX: 0, y: -self.passwordInputView.frame.height*2.6)
+            })
+        default:
+            break
+        }
+        return true
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        switch textField {
+        case self.emailInputView.textField:
+            self.passwordInputView.textField?.becomeFirstResponder()
+        case self.passwordInputView.textField:
+            self.passwordCheckInputView.textField?.becomeFirstResponder()
+        case self.passwordCheckInputView.textField:
+            UIView.animate(withDuration: 0.2, animations: {
+                self.view.frame.origin = CGPoint(x: 0, y: 0)
+            })
+            textField.endEditing(true)
+        default:
+            break
+        }
+        return true
     }
 }
 
@@ -373,7 +415,7 @@ extension SignUpViewController {
         self.signupButton.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.signupButton)
         NSLayoutConstraint.activate([
-            self.signupButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -70),
+            self.signupButton.topAnchor.constraint(equalTo: self.passwordCheckInputView.bottomAnchor),
             self.signupButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
             self.signupButton.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: Constant.middleWidthRatio),
             self.signupButton.heightAnchor.constraint(equalToConstant: Constant.signupButtonHeight)

--- a/Escaper/Escaper/Presentation/Login/Views/UserInputTextField.swift
+++ b/Escaper/Escaper/Presentation/Login/Views/UserInputTextField.swift
@@ -84,13 +84,13 @@ extension UserInputTextField {
         switch viewType {
         case .email:
             self.imageView.image = EDSImage.emailIcon.value
-            self.attributedPlaceholder = NSAttributedString(string: "이메일", attributes: [NSAttributedString.Key.foregroundColor: EDSColor.skullLightWhite.value as Any])
+            self.attributedPlaceholder = NSAttributedString(string: "이메일", attributes: [NSAttributedString.Key.foregroundColor: EDSColor.skullLightWhite.value as Any, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .regular)])
         case .password:
             self.imageView.image = EDSImage.passwordIcon.value
-            self.attributedPlaceholder = NSAttributedString(string: "비밀번호", attributes: [NSAttributedString.Key.foregroundColor: EDSColor.skullLightWhite.value as Any])
+            self.attributedPlaceholder = NSAttributedString(string: "비밀번호", attributes: [NSAttributedString.Key.foregroundColor: EDSColor.skullLightWhite.value as Any, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .regular)])
         case .passwordCheck:
             self.imageView.image = EDSImage.passwordIcon.value
-            self.attributedPlaceholder = NSAttributedString(string: "비밀번호 확인", attributes: [NSAttributedString.Key.foregroundColor: EDSColor.skullLightWhite.value as Any])
+            self.attributedPlaceholder = NSAttributedString(string: "비밀번호 확인", attributes: [NSAttributedString.Key.foregroundColor: EDSColor.skullLightWhite.value as Any, NSAttributedString.Key.font: UIFont.systemFont(ofSize: 15, weight: .regular)])
         }
     }
 

--- a/Escaper/Escaper/Presentation/Login/Views/UserInputView.swift
+++ b/Escaper/Escaper/Presentation/Login/Views/UserInputView.swift
@@ -40,19 +40,8 @@ private extension UserInputView {
     }
 
     func configureLayout() {
-        self.configureGuideWordsLabelLayout()
         self.configureTextFieldLayout()
-    }
-
-    func configureGuideWordsLabelLayout() {
-        self.guideWordsLabel.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(self.guideWordsLabel)
-        NSLayoutConstraint.activate([
-            self.guideWordsLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.guideWordsLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.guideWordsLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            self.guideWordsLabel.heightAnchor.constraint(equalToConstant: 15)
-        ])
+        self.configureGuideWordsLabelLayout()
     }
 
     func configureTextFieldLayout() {
@@ -63,8 +52,20 @@ private extension UserInputView {
                 textField.topAnchor.constraint(equalTo: self.topAnchor),
                 textField.leadingAnchor.constraint(equalTo: self.leadingAnchor),
                 textField.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-                textField.bottomAnchor.constraint(equalTo: self.guideWordsLabel.topAnchor)
+                textField.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.6)
             ])
         }
+    }
+
+    func configureGuideWordsLabelLayout() {
+        self.guideWordsLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(self.guideWordsLabel)
+        NSLayoutConstraint.activate([
+            self.guideWordsLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.guideWordsLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.guideWordsLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            self.guideWordsLabel.topAnchor.constraint(equalTo: self.textField!.bottomAnchor),
+            self.guideWordsLabel.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.4)
+        ])
     }
 }


### PR DESCRIPTION
issue number : [#113](../issues/113)
issue number : [#122](../issues/122)
close #113
close #122

### 작업 사항

로그인 화면 오토레이아웃을 비율을 사용하도록 수정
회원가입 화면 오토레이아웃을 비율을 사용하도록 수정
회원가입 화면의 이미지 선택 개선
로그인 및 회원가입 화면의 텍스트필드 동작 개선
(return을 통해 다음 텍스트 필드로 이동 가능, 화면을 클릭하면 키보드가 사라짐, 작성하고 있는 텍스트 필드에 맞게 뷰 위치 이동)

