### PR TITLE
Refresh control 달기

### DIFF
--- a/Escaper/Escaper.xcodeproj/project.pbxproj
+++ b/Escaper/Escaper.xcodeproj/project.pbxproj
@@ -608,8 +608,8 @@
 				3E4378C827325241001ED120 /* TagScrollView.swift */,
 				3E4378CA27329028001ED120 /* TagButton.swift */,
 				251031C52733BCAC00BD07BF /* RatingContainerView.swift */,
-				255133642730F07000A92CF3 /* Cell */,
 				251CA9AC27525C5B00BA5EC5 /* EmptyResultView.swift */,
+				255133642730F07000A92CF3 /* Cell */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/Escaper/Escaper/Presentation/LeaderBoard/LeaderBoardViewModel.swift
+++ b/Escaper/Escaper/Presentation/LeaderBoard/LeaderBoardViewModel.swift
@@ -26,7 +26,7 @@ final class DefaultLeadeBoardViewModel: LeaderBoardViewModelInterface {
         self.usecase.fetch { [weak self] result in
             switch result {
             case .success(let users):
-                self? .users.value = users.sorted {$0.score > $1.score}
+                self?.users.value = users.sorted {$0.score > $1.score}
             case .failure(let error):
                 print(error)
             }

--- a/Escaper/Escaper/Presentation/RoomList/Views/EmptyResultView.swift
+++ b/Escaper/Escaper/Presentation/RoomList/Views/EmptyResultView.swift
@@ -8,9 +8,13 @@
 import UIKit
 
 class EmptyResultView: UIView {
-    private let imageView: UIImageView = UIImageView(image: UIImage(named: Genre.fear.detailImageAssetName))
+    private let imageView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(named: Genre.romance.detailImageAssetName))
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
     private let contentLabel: UILabel = {
-        let label = EDSLabel.b01B(text: "검색 결과가 없어요. 다른 지역을 선택해주세요.", color: .skullWhite)
+        let label = EDSLabel.b01R(text: "검색 결과가 없어요. 다른 지역을 선택해주세요.", color: .skullWhite)
         label.textAlignment = .center
         return label
     }()


### PR DESCRIPTION
issue number : [#204](../issues/204)
close #204

### 작업 사항

- 검색결과 없을시 보이는 이미지의 scale aspect fill로 변경
- 리더보드 타이틀은 스크롤뷰에서 뺌
- 리더보드 위로 스크롤시 리로드되도록 추가


검색 결과 | 리로드
-- | --
![image](https://user-images.githubusercontent.com/37871541/143800107-aa083b76-ff6d-4d01-afc1-f5e7e8d55921.png)| ![image](https://user-images.githubusercontent.com/37871541/143800151-908e00e7-1d1e-43f6-bd38-79237fccb41c.png)
