### PR TITLE
[E11 T50] 기록 추가 화면 이미 다녀온 테마 선택 불가 구현

### DIFF
--- a/Escaper/Escaper.xcodeproj/project.pbxproj
+++ b/Escaper/Escaper.xcodeproj/project.pbxproj
@@ -1124,7 +1124,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4;
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.escaper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1156,7 +1156,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4;
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.escaper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Escaper/Escaper/Domain/Entities/RecordCard.swift
+++ b/Escaper/Escaper/Domain/Entities/RecordCard.swift
@@ -33,4 +33,8 @@ struct RecordCard: Hashable {
         self.rank = Helper.binarySearch(value: record.escapingTime, sortedValues: room.records.map({ $0.escapingTime }).sorted()) ?? room.records.count
         self.time = record.escapingTime
     }
+
+    static func == (lhs: RecordCard, rhs: RecordCard) -> Bool {
+        return lhs.username == rhs.username && lhs.storeName == rhs.storeName && lhs.roomTitle == rhs.roomTitle
+    }
 }

--- a/Escaper/Escaper/Presentation/AddRecord/AddRecordViewController.swift
+++ b/Escaper/Escaper/Presentation/AddRecord/AddRecordViewController.swift
@@ -114,12 +114,18 @@ extension AddRecordViewController: TimePickerDelegate {
         self.recordView.updateTimePicker(minutes: minutes, seconds: seconds)
     }
 }
-
+// TODO: alert
 extension AddRecordViewController: RoomInformationTransferable {
     func transfer(room: Room) {
-        self.recordView.updateRoomInformation(room)
-        self.viewModel?.room = room
-        self.viewModel?.changeSaveState()
+        guard let isVisited = self.viewModel?.updateRoom(room) else { return }
+        if isVisited {
+            self.recordView.updateRoomInformation(room)
+        } else {
+            let alert = UIAlertController(title: "경고", message: "이미 다녀온 테마입니다.", preferredStyle: .alert)
+            let defaultAction = UIAlertAction(title: "OK", style: .destructive)
+            alert.addAction(defaultAction)
+            self.present(alert, animated: false, completion: nil)
+        }
     }
 }
 

--- a/Escaper/Escaper/Presentation/AddRecord/AddRecordViewModel.swift
+++ b/Escaper/Escaper/Presentation/AddRecord/AddRecordViewModel.swift
@@ -18,6 +18,7 @@ protocol AddRecordViewModelOutput {
     var time: Int { get set }
     var records: [Record] { get set }
     var state: Observable<Bool> { get }
+    func updateRoom(_ room: Room) -> Bool
 
     func changeSaveState()
 }
@@ -41,6 +42,17 @@ final class AddRecordViewModel: AddRecordViewModelInput, AddRecordViewModelOutpu
         self.time = .zero
         self.records = []
         self.state = Observable(false)
+    }
+
+    func updateRoom(_ room: Room) -> Bool {
+        let userEmail = UserSupervisor.shared.email
+        let visited = room.records.contains { record in
+            record.userEmail == userEmail
+        }
+        self.room = visited ? nil : room
+        self.records = self.room?.records ?? []
+        self.changeSaveState()
+        return !visited
     }
 
     func changeSaveState() {

--- a/Escaper/Escaper/Presentation/LeaderBoard/LeaderBoardViewController.swift
+++ b/Escaper/Escaper/Presentation/LeaderBoard/LeaderBoardViewController.swift
@@ -118,7 +118,7 @@ private extension LeaderBoardViewController {
     }
 
     func updateStackView(users: [User]) {
-        self.userRankStackView.arrangedSubviews.forEach{ $0.removeFromSuperview() }
+        self.userRankStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         for (rank, user) in users.enumerated() {
             let rankView = RoomDetailUserRankView()
             rankView.translatesAutoresizingMaskIntoConstraints = false

--- a/Escaper/Escaper/Presentation/Record/RecordViewController.swift
+++ b/Escaper/Escaper/Presentation/Record/RecordViewController.swift
@@ -74,6 +74,10 @@ class RecordViewController: DefaultViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         if UserSupervisor.shared.isLogined {
+            guard let userName = Helper.parseUsername(email: UserSupervisor.shared.email), let records = self.viewModel?.records.value else { return }
+            if !records.allSatisfy({ $0.username == userName }) {
+                self.viewModel?.records.value = []
+            }
             self.viewModel?.fetch(userEmail: UserSupervisor.shared.email)
         } else {
             self.recordDefaultGuideView.isHidden = false
@@ -81,8 +85,6 @@ class RecordViewController: DefaultViewController {
             self.addButton.isHidden = true
             self.countingLabel.text = "👻"
             self.greetingLabel.text = "당신의 실력은 어느 수준일까요?"
-            self.viewModel?.records.value = []
-            self.applyRecordCollectionViewData(recordCards: [], animated: false)
         }
     }
 
@@ -117,7 +119,8 @@ class RecordViewController: DefaultViewController {
 
 extension RecordViewController: AddRecordViewControllerDelegate {
     func addRecordButtonTouched() {
-        self.viewModel?.fetch(userEmail: UserSupervisor.shared.email)
+        // TODO: ViewWillAppear와 두번 호출 문제 발생 
+        //        self.viewModel?.fetch(userEmail: UserSupervisor.shared.email)
         if self.recordCollectionView.numberOfItems(inSection: .zero) != .zero {
             self.recordCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .left, animated: true)
         }
@@ -265,7 +268,6 @@ private extension RecordViewController {
                 animateZoomforCellremove(zoomCell: cell)
             }
         }
-
     }
 
     func configureRecordCollectionViewDataSource() {

--- a/Escaper/Escaper/Presentation/Record/Views/Cells/RecordUserView.swift
+++ b/Escaper/Escaper/Presentation/Record/Views/Cells/RecordUserView.swift
@@ -84,6 +84,8 @@ final class RecordUserView: UIView {
     func prepareForReuse() {
         self.nicknameLabel.text = ""
         self.resultLabel.text = ""
+        // TODO: 셀 Reuse 이미지 업데이트 문제
+//        self.userImageView.image = nil
     }
 }
 
@@ -94,7 +96,7 @@ private extension RecordUserView {
     }
 
     enum Result: String {
-        case success = "Sucess"
+        case success = "Success"
         case fail = "Fail"
 
         var name: String {

--- a/Escaper/Escaper/Presentation/SearchRoom/SearchRoomViewController.swift
+++ b/Escaper/Escaper/Presentation/SearchRoom/SearchRoomViewController.swift
@@ -73,8 +73,9 @@ extension SearchRoomViewController: UISearchBarDelegate {
 extension SearchRoomViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let selectedRoom = self.dataSource?.itemIdentifier(for: indexPath) else { return }
-        self.roomTransferDelegate?.transfer(room: selectedRoom)
-        self.dismiss(animated: true)
+        self.dismiss(animated: true) {
+            self.roomTransferDelegate?.transfer(room: selectedRoom)
+        }
     }
 }
 

--- a/Escaper/Escaper/Presentation/Setting/Views/UserLoginedView.swift
+++ b/Escaper/Escaper/Presentation/Setting/Views/UserLoginedView.swift
@@ -30,7 +30,9 @@ final class UserLoginedView: UserSettingView {
             case .success(let data):
                 let image = UIImage(data: data)
                 guard let username = Helper.parseUsername(email: UserSupervisor.shared.email) else { return }
-                super.inject(image: image, title: username)
+                DispatchQueue.main.async {
+                    super.inject(image: image, title: username)
+                }
             case .failure(let error):
                 print(error)
             }


### PR DESCRIPTION
issue number : [#220](../issues/220)
close #220

### 작업 사항
- 기존에 다녀온 테마 선택시 Alert띠움
- 기록 추가시 생성한 Date()와 Firebase에 등록된 CreateTime이 시분초 외에 timerinterval이 상이해서 발생한 문제 해결
- 설정화면에서 로그아웃 후 다른 아이디로 로그인시 기존 데이터와 새로 로그인한 데이터가 중복되는 문제 해결
- 배포로 인한 버전 변경
