### PR TITLE
[E11 T19] 네비게이션 바 투명하게 만들기 & MainTabBar 리팩토링

### DIFF
--- a/Escaper/Escaper.xcodeproj/project.pbxproj
+++ b/Escaper/Escaper.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0CEE8B3A275212FF00E6C6EA /* RoomDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEE8B39275212FF00E6C6EA /* RoomDetailRepository.swift */; };
 		0CEE8B3C2754B37200E6C6EA /* daehakro.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CEE8B3B2754B37200E6C6EA /* daehakro.json */; };
 		0CEE8B3E2754F66900E6C6EA /* sinchon.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CEE8B3D2754F66900E6C6EA /* sinchon.json */; };
+		0CEE8B4027564B7900E6C6EA /* DefaultNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEE8B3F27564B7900E6C6EA /* DefaultNavigationViewController.swift */; };
 		1F061DA8272FF896008FC519 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 1F061DA7272FF896008FC519 /* .swiftlint.yml */; };
 		1F43615B274FE8CA00331C6F /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F43615A274FE8CA00331C6F /* RatingView.swift */; };
 		1F884BC32740D4E500DE67D8 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 1F884BC22740D4E500DE67D8 /* FirebaseFirestore */; };
@@ -155,6 +156,7 @@
 		0CEE8B39275212FF00E6C6EA /* RoomDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDetailRepository.swift; sourceTree = "<group>"; };
 		0CEE8B3B2754B37200E6C6EA /* daehakro.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = daehakro.json; sourceTree = "<group>"; };
 		0CEE8B3D2754F66900E6C6EA /* sinchon.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = sinchon.json; sourceTree = "<group>"; };
+		0CEE8B3F27564B7900E6C6EA /* DefaultNavigationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNavigationViewController.swift; sourceTree = "<group>"; };
 		1F061DA7272FF896008FC519 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		1F0CAED22733E00300389CFA /* RoomDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDTO.swift; sourceTree = "<group>"; };
 		1F0CAED42733E03600389CFA /* FirebaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseService.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				25F92C5E273A2AC3005E4A21 /* MainTabBarController.swift */,
 				3E4378CC2732914B001ED120 /* DefaultViewController.swift */,
 				1F43615A274FE8CA00331C6F /* RatingView.swift */,
+				0CEE8B3F27564B7900E6C6EA /* DefaultNavigationViewController.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -961,6 +964,7 @@
 				251CA9A5274FE0AF00BA5EC5 /* FeedbackRepository.swift in Sources */,
 				251CA991274F86BA00BA5EC5 /* UserLoginedView.swift in Sources */,
 				0CEE8B362752113F00E6C6EA /* RoomDetailUseCase.swift in Sources */,
+				0CEE8B4027564B7900E6C6EA /* DefaultNavigationViewController.swift in Sources */,
 				3EBB5ACD274E35C000715F89 /* ImageCacheManager.swift in Sources */,
 				3EBB5ACE274E35C000715F89 /* NetworkService.swift in Sources */,
 				0CEE8B3A275212FF00E6C6EA /* RoomDetailRepository.swift in Sources */,

--- a/Escaper/Escaper/Presentation/Common/DefaultNavigationViewController.swift
+++ b/Escaper/Escaper/Presentation/Common/DefaultNavigationViewController.swift
@@ -1,0 +1,41 @@
+//
+//  DefaultNavigationViewController.swift
+//  Escaper
+//
+//  Created by 박영광 on 2021/11/30.
+//
+
+import UIKit
+
+final class DefaultNavigationViewController: UINavigationController {
+    private let navigationAppearance: UINavigationBarAppearance = {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .clear
+        appearance.backgroundEffect = .none
+        appearance.shadowColor = .clear
+        return appearance
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override init(rootViewController: UIViewController) {
+        super.init(rootViewController: rootViewController)
+        self.configure()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.configure()
+    }
+}
+
+private extension DefaultNavigationViewController {
+    func configure() {
+        self.navigationBar.standardAppearance = self.navigationAppearance
+        self.navigationBar.scrollEdgeAppearance = self.navigationAppearance
+        self.navigationBar.tintColor = EDSColor.skullLightWhite.value
+        self.navigationBar.topItem?.title = ""
+    }
+}

--- a/Escaper/Escaper/Presentation/Common/MainTabBarController.swift
+++ b/Escaper/Escaper/Presentation/Common/MainTabBarController.swift
@@ -53,16 +53,15 @@ private extension MainTabBarController {
             let navigationController = UINavigationController(rootViewController: homeViewController)
             let navigationAppearance: UINavigationBarAppearance = {
                 let appearance = UINavigationBarAppearance()
-                appearance.backgroundColor = EDSColor.bloodyBlack.value
+                appearance.backgroundColor = .clear
+                appearance.backgroundEffect = .none
+                appearance.shadowColor = .clear
                 return appearance
             }()
             navigationController.navigationBar.standardAppearance = navigationAppearance
+            navigationController.navigationBar.scrollEdgeAppearance = navigationAppearance
             navigationController.navigationBar.tintColor = EDSColor.skullLightWhite.value
             navigationController.navigationBar.topItem?.title = ""
-            if #available(iOS 15.0, *) {
-                navigationController.navigationBar.compactScrollEdgeAppearance = navigationAppearance
-                navigationController.navigationBar.scrollEdgeAppearance = navigationAppearance
-            }
             return navigationController
         }()
         let recordBarItem = self.makeTabBarItem(
@@ -86,16 +85,15 @@ private extension MainTabBarController {
             let navigationController = UINavigationController(rootViewController: mapViewController)
             let navigationAppearance: UINavigationBarAppearance = {
                 let appearance = UINavigationBarAppearance()
-                appearance.backgroundColor = EDSColor.bloodyBlack.value
+                appearance.backgroundColor = .clear
+                appearance.backgroundEffect = .none
+                appearance.shadowColor = .clear
                 return appearance
             }()
             navigationController.navigationBar.standardAppearance = navigationAppearance
+            navigationController.navigationBar.scrollEdgeAppearance = navigationAppearance
             navigationController.navigationBar.tintColor = EDSColor.skullLightWhite.value
             navigationController.navigationBar.topItem?.title = ""
-            if #available(iOS 15.0, *) {
-                navigationController.navigationBar.compactScrollEdgeAppearance = navigationAppearance
-                navigationController.navigationBar.scrollEdgeAppearance = navigationAppearance
-            }
             return navigationController
         }()
         let leaderBoardBarItem = self.makeTabBarItem(

--- a/Escaper/Escaper/Presentation/Common/MainTabBarController.swift
+++ b/Escaper/Escaper/Presentation/Common/MainTabBarController.swift
@@ -9,20 +9,7 @@ import UIKit
 import AVFoundation
 
 final class MainTabBarController: UITabBarController {
-    enum Constant {
-        static let itemInset = CGFloat(10)
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        self.configureDelegates()
-        self.configureTabBar()
-        self.configureSubViewControllers()
-    }
-}
-
-private extension MainTabBarController {
-    enum TabBarItemConfig: String {
+    internal enum TabBarItemConfig: String {
         case home = "홈"
         case record = "기록"
         case map = "지도"
@@ -40,78 +27,43 @@ private extension MainTabBarController {
         }
     }
 
-    func configureTabBar() {
-        let homeBarItem = self.makeTabBarItem(
-            title: TabBarItemConfig.home.title,
-            unselected: TabBarItemConfig.home.unselectedImage,
-            selected: TabBarItemConfig.home.selectedImage
-        )
-        let homeViewController = RoomListViewController()
-        homeViewController.tabBarItem = homeBarItem
-        homeViewController.create()
-        let homeNavigationController: UINavigationController = {
-            let navigationController = UINavigationController(rootViewController: homeViewController)
-            let navigationAppearance: UINavigationBarAppearance = {
-                let appearance = UINavigationBarAppearance()
-                appearance.backgroundColor = .clear
-                appearance.backgroundEffect = .none
-                appearance.shadowColor = .clear
-                return appearance
-            }()
-            navigationController.navigationBar.standardAppearance = navigationAppearance
-            navigationController.navigationBar.scrollEdgeAppearance = navigationAppearance
-            navigationController.navigationBar.tintColor = EDSColor.skullLightWhite.value
-            navigationController.navigationBar.topItem?.title = ""
-            return navigationController
-        }()
-        let recordBarItem = self.makeTabBarItem(
-            title: TabBarItemConfig.record.title,
-            unselected: TabBarItemConfig.record.unselectedImage,
-            selected: TabBarItemConfig.record.selectedImage
-        )
-        let recordViewController = RecordViewController()
-        recordViewController.tabBarItem = recordBarItem
-        recordViewController.create()
-        let mapBarItem = self.makeTabBarItem(
-            title: TabBarItemConfig.map.title,
-            unselected: TabBarItemConfig.map.unselectedImage,
-            selected: TabBarItemConfig.map.selectedImage
-        )
-        let mapViewController = MapViewController()
-        mapViewController.tabBarItem = mapBarItem
-        mapViewController.create()
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureDelegate()
+        self.configure()
+        self.configureTabBar()
+    }
+}
 
-        let mapNavigationController: UINavigationController = {
-            let navigationController = UINavigationController(rootViewController: mapViewController)
-            let navigationAppearance: UINavigationBarAppearance = {
-                let appearance = UINavigationBarAppearance()
-                appearance.backgroundColor = .clear
-                appearance.backgroundEffect = .none
-                appearance.shadowColor = .clear
-                return appearance
-            }()
-            navigationController.navigationBar.standardAppearance = navigationAppearance
-            navigationController.navigationBar.scrollEdgeAppearance = navigationAppearance
-            navigationController.navigationBar.tintColor = EDSColor.skullLightWhite.value
-            navigationController.navigationBar.topItem?.title = ""
-            return navigationController
-        }()
-        let leaderBoardBarItem = self.makeTabBarItem(
-            title: TabBarItemConfig.leaderBoard.title,
-            unselected: TabBarItemConfig.leaderBoard.unselectedImage,
-            selected: TabBarItemConfig.leaderBoard.selectedImage
-        )
+private extension MainTabBarController {
+    func configure() {
+        let homeBarItem = self.makeTabBarItem(config: .home)
+        let homeViewController = RoomListViewController()
+        homeViewController.create()
+        let homeNavigationController = DefaultNavigationViewController(rootViewController: homeViewController)
+        homeNavigationController.tabBarItem = homeBarItem
+
+        let recordBarItem = self.makeTabBarItem(config: .record)
+        let recordViewController = RecordViewController()
+        recordViewController.create()
+        recordViewController.tabBarItem = recordBarItem
+
+        let mapBarItem = self.makeTabBarItem(config: .map)
+        let mapViewController = MapViewController()
+        mapViewController.create()
+        let mapNavigationController = DefaultNavigationViewController(rootViewController: mapViewController)
+        mapNavigationController.tabBarItem = mapBarItem
+
+        let leaderBoardBarItem = self.makeTabBarItem(config: .leaderBoard)
         let leaderBoardViewController = LeaderBoardViewController()
-        leaderBoardViewController.tabBarItem = leaderBoardBarItem
         leaderBoardViewController.create()
-        let settingBarItem = self.makeTabBarItem(
-            title: TabBarItemConfig.setting.title,
-            unselected: TabBarItemConfig.setting.unselectedImage,
-            selected: TabBarItemConfig.setting.selectedImage
-        )
+        leaderBoardViewController.tabBarItem = leaderBoardBarItem
+
+        let settingBarItem = self.makeTabBarItem(config: .setting)
         let settingViewController = SettingViewController()
         settingViewController.create()
         settingViewController.tabBarItem = settingBarItem
+
         let viewControllers = [
             homeNavigationController,
             recordViewController,
@@ -122,7 +74,7 @@ private extension MainTabBarController {
         self.viewControllers = viewControllers
     }
 
-    func configureSubViewControllers() {
+    func configureTabBar() {
         let tabBarAppearance: UITabBarAppearance = {
             let appearance = UITabBarAppearance()
             appearance.backgroundColor = EDSColor.gloomyLightBrown.value
@@ -134,19 +86,19 @@ private extension MainTabBarController {
         self.tabBar.barTintColor = EDSColor.skullLightWhite.value
     }
 
-    func makeTabBarItem(title: String, unselected: UIImage?, selected: UIImage?) -> UITabBarItem {
+    func makeTabBarItem(config: TabBarItemConfig) -> UITabBarItem {
         let item = UITabBarItem(
-            title: title,
-            image: unselected,
-            selectedImage: selected
+            title: config.title,
+            image: config.unselectedImage,
+            selectedImage: config.selectedImage
         )
-        item.imageInsets = UIEdgeInsets(top: Constant.itemInset, left: Constant.itemInset, bottom: Constant.itemInset, right: Constant.itemInset)
+        item.imageInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
         return item
     }
 }
 
 extension MainTabBarController: UITabBarControllerDelegate {
-    private func configureDelegates() {
+    private func configureDelegate() {
         self.delegate = self
     }
 

--- a/Escaper/Escaper/Presentation/RoomDetail/RoomDetailViewController.swift
+++ b/Escaper/Escaper/Presentation/RoomDetail/RoomDetailViewController.swift
@@ -93,7 +93,7 @@ private extension RoomDetailViewController {
         NSLayoutConstraint.activate([
             self.scrollView.frameLayoutGuide.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
             self.scrollView.frameLayoutGuide.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
-            self.scrollView.frameLayoutGuide.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            self.scrollView.frameLayoutGuide.topAnchor.constraint(equalTo: self.view.topAnchor),
             self.scrollView.frameLayoutGuide.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
         ])
     }


### PR DESCRIPTION
issue number : [#227](../issues/227)
close #227 

### 작업 사항
- 네비게이션 바 투명하게 만들기
![Simulator Screen Recording - iPhone 12 - 2021-11-30 at 21 51 14](https://user-images.githubusercontent.com/48627117/144050939-6c939168-ecac-4e8d-8455-2d34792a9f16.gif)

- MainTabBar 리팩토링


## 학습 사항

iOS13부터 standard / compact / scrollEdge Appearance 옵션이 생겼습니다.

- standard → large title이 없는 사이즈
- compact → iphone portrait가 landscape일때 처럼 넓어 질 때
- scrollable한 뷰의 엣지가 bar에 도달 할 경우

### 이렇게 뒤에 불투명한 뷰가 있음. -> appearance.backgroundEffect = .none로 제거 가능! 
![image](https://user-images.githubusercontent.com/48627117/144051115-dcfcef83-b0d2-4245-ba7b-2fda1fc9f61d.png)


