### PR TITLE
[E11 T56, T57] 앱스토어 거절 - 앱스토어 리뷰 반영

### DIFF
--- a/Escaper/Escaper/Info.plist
+++ b/Escaper/Escaper/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>기록을 추가하기 위해 권한이 필요합니다. (필수권한)</string>
+	<string>기록을 추가하기 위해 권한이 필요합니다. </string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>현재위치를 확인하기 위해 권한이 필요합니다. (필수권한)</string>
+	<string>현재위치를 기반으로 방탈출 카페를 보여주기 위해 권한이 필요합니다. </string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>UIStatusBarStyle</key>
@@ -41,9 +41,5 @@
 			</array>
 		</dict>
 	</dict>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleLightContent</string>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 </dict>
 </plist>

--- a/Escaper/Escaper/Presentation/AddRecord/AddRecordViewController.swift
+++ b/Escaper/Escaper/Presentation/AddRecord/AddRecordViewController.swift
@@ -115,7 +115,7 @@ extension AddRecordViewController: TimePickerDelegate {
         self.recordView.updateTimePicker(minutes: minutes, seconds: seconds)
     }
 }
-// TODO: alert
+
 extension AddRecordViewController: RoomInformationTransferable {
     func transfer(room: Room) {
         guard let isVisited = self.viewModel?.updateRoom(room) else { return }

--- a/Escaper/Escaper/Presentation/AddRecord/AddRecordViewController.swift
+++ b/Escaper/Escaper/Presentation/AddRecord/AddRecordViewController.swift
@@ -7,13 +7,7 @@
 
 import UIKit
 
-protocol AddRecordViewControllerDelegate: AnyObject {
-    func addRecordButtonTouched()
-}
-
 final class AddRecordViewController: DefaultViewController {
-    private weak var delegate: AddRecordViewControllerDelegate?
-
     private var viewModel: (AddRecordViewModelInput & AddRecordViewModelOutput)?
     private let titleLabel: UILabel = EDSLabel.h02B(text: "기록 추가", color: .skullLightWhite)
     private let backButton: UIButton = {
@@ -40,14 +34,13 @@ final class AddRecordViewController: DefaultViewController {
         self.configureLayout()
     }
 
-    func create(delegateTarget: AddRecordViewControllerDelegate) {
+    func create() {
         let recordRepository = RecordRepository(service: FirebaseService.shared)
         let roomRepository = RoomListRepository(service: FirebaseService.shared)
         let userRepository = UserRepository(service: FirebaseService.shared)
         let recordUsecase = RecordUsecase(roomRepository: roomRepository, recordRepository: recordRepository)
         let userUsecase = UserUseCase(userRepository: userRepository)
         let viewModel = AddRecordViewModel(recordUsecase: recordUsecase, userUsecase: userUsecase)
-        self.delegate = delegateTarget
         self.viewModel = viewModel
     }
 
@@ -63,7 +56,6 @@ final class AddRecordViewController: DefaultViewController {
             switch result {
             case .success(let urlString):
                 self?.viewModel?.post(email: userEmail, imageURLString: urlString)
-                self?.delegate?.addRecordButtonTouched()
                 self?.dismiss(animated: true)
             case .failure(let error):
                 print(error)

--- a/Escaper/Escaper/Presentation/AddRecord/AddRecordViewModel.swift
+++ b/Escaper/Escaper/Presentation/AddRecord/AddRecordViewModel.swift
@@ -38,7 +38,7 @@ final class AddRecordViewModel: AddRecordViewModelInput, AddRecordViewModelOutpu
         self.userUsecase = userUsecase
         self.room = nil
         self.satisfaction = .zero
-        self.isSuccess = true
+        self.isSuccess = false
         self.time = .zero
         self.records = []
         self.state = Observable(false)
@@ -56,13 +56,16 @@ final class AddRecordViewModel: AddRecordViewModelInput, AddRecordViewModelOutpu
     }
 
     func changeSaveState() {
-        self.state.value = self.room != nil && self.time != 0
+        if self.isSuccess {
+            self.state.value = self.room != nil && self.time != 0
+        } else {
+            self.state.value = self.room != nil
+        }
     }
 
     func calculateScore() -> Int? {
         guard let timeLimit = self.room?.timeLimit,
-              let diffculty = self.room?.difficulty,
-              self.time != .zero else { return nil }
+              let diffculty = self.room?.difficulty else { return nil }
         let score = Int((self.isSuccess ? 1 : 0) * (1 - Double(self.time)/Double(timeLimit*60)) * 100 * Double(diffculty) + 50.0)
         return score
     }

--- a/Escaper/Escaper/Presentation/AddRecord/View/AddRecordView.swift
+++ b/Escaper/Escaper/Presentation/AddRecord/View/AddRecordView.swift
@@ -58,14 +58,15 @@ final class AddRecordView: UIView {
         let segmentControl = UISegmentedControl(items: ["Success", "Fail"])
         segmentControl.tintColor = .clear
         segmentControl.layer.backgroundColor = EDSColor.skullLightWhite.value!.cgColor
-        segmentControl.selectedSegmentIndex = 0
-        segmentControl.selectedSegmentTintColor = EDSColor.pumpkin.value
+        segmentControl.selectedSegmentIndex = 1
+        segmentControl.selectedSegmentTintColor = EDSColor.bloodyRed.value
         return segmentControl
     }()
     private let escapingTimePickerButton: UIButton = {
         let button = UIButton()
         button.isEnabled = false
         button.setTitle("00 : 00", for: .normal)
+        button.setTitle("None", for: .disabled)
         button.setTitleColor(EDSColor.charcoal.value, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: 10, weight: .bold)
         button.backgroundColor = EDSColor.skullWhite.value
@@ -135,10 +136,12 @@ final class AddRecordView: UIView {
         self.delegate?.escapingTimePickerButtonTapped()
     }
 
-    @objc func escapingStatusSegmentControlChanged() {
-        let currentColor = self.escapingStatusSegmentControl.selectedSegmentIndex == 0 ? EDSColor.pumpkin : EDSColor.bloodyRed
-        self.escapingStatusSegmentControl.selectedSegmentTintColor = currentColor.value
-        self.delegate?.updateIsSuccess(self.escapingStatusSegmentControl.selectedSegmentIndex == 0)
+    @objc func escapingStatusSegmentControlChanged(sender: UISegmentedControl) {
+        let isSuccess = sender.selectedSegmentIndex == 0
+        let currentColor = isSuccess ? EDSColor.pumpkin : EDSColor.bloodyRed
+        sender.selectedSegmentTintColor = currentColor.value
+        self.escapingTimePickerButton.isEnabled = isSuccess && self.findRoomTitleButton.currentImage == nil
+        self.delegate?.updateIsSuccess(isSuccess)
         self.hapticsGenerator()
     }
 
@@ -155,7 +158,7 @@ final class AddRecordView: UIView {
         self.findRoomTitleButton.setTitle(room.title, for: .normal)
         self.findRoomTitleButton.setImage(nil, for: .normal)
         self.roomStoreTitleLabel.text = room.storeName
-        self.escapingTimePickerButton.isEnabled = true
+        self.escapingTimePickerButton.isEnabled = self.escapingStatusSegmentControl.selectedSegmentIndex == 0
     }
 
     func updateTimePicker(minutes: Int, seconds: Int) {

--- a/Escaper/Escaper/Presentation/AddRecord/View/AddRecordView.swift
+++ b/Escaper/Escaper/Presentation/AddRecord/View/AddRecordView.swift
@@ -246,7 +246,8 @@ private extension AddRecordView {
         NSLayoutConstraint.activate([
             self.roomInformationStackView.topAnchor.constraint(equalTo: self.userSelectedImageView.bottomAnchor, constant: 30),
             self.roomInformationStackView.centerXAnchor.constraint(equalTo: self.recordBackgroundImageView.centerXAnchor),
-            self.roomInformationStackView.widthAnchor.constraint(lessThanOrEqualTo: self.recordBackgroundImageView.widthAnchor)
+            self.roomInformationStackView.widthAnchor.constraint(equalTo: self.recordBackgroundImageView.widthAnchor, multiplier: 0.7),
+            self.roomInformationStackView.heightAnchor.constraint(equalToConstant: 50)
         ])
     }
 

--- a/Escaper/Escaper/Presentation/AddRecord/View/AddRecordView.swift
+++ b/Escaper/Escaper/Presentation/AddRecord/View/AddRecordView.swift
@@ -125,7 +125,7 @@ final class AddRecordView: UIView {
 
     override func draw(_ rect: CGRect) {
         super.draw(rect)
-        self.satisFactionRatingView.starSize = (Int(self.satisFactionRatingView.frame.width) - self.satisFactionRatingView.starSpacing * 4) / 5 - 5
+        self.satisFactionRatingView.starSize = (Int(self.satisFactionRatingView.frame.width) - self.satisFactionRatingView.starSpacing * 4) / 5
     }
 
     @objc func findRoomButtonTouched() {
@@ -197,6 +197,7 @@ private extension AddRecordView {
         self.configureImagePickerButtonLayout()
         self.configurArrrangeSubViews()
         self.configureEscapingtimePickerButtonLayout()
+        self.configureRatingViewLayout()
         self.configureRoomInformationStackViewLayout()
         self.configureEscapingStackViewLayout()
     }
@@ -237,9 +238,16 @@ private extension AddRecordView {
     }
 
     func configureEscapingtimePickerButtonLayout() {
-        self.escapingTimePickerButton.translatesAutoresizingMaskIntoConstraints = false
+        self.satisFactionRatingView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             self.escapingTimePickerButton.widthAnchor.constraint(equalTo: self.escapingInputStackView.widthAnchor, multiplier: 0.5)
+        ])
+    }
+
+    func configureRatingViewLayout() {
+        self.escapingTimePickerButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.satisFactionRatingView.widthAnchor.constraint(equalTo: self.escapingInputStackView.widthAnchor, multiplier: 0.7)
         ])
     }
 

--- a/Escaper/Escaper/Presentation/Common/RatingView.swift
+++ b/Escaper/Escaper/Presentation/Common/RatingView.swift
@@ -51,14 +51,14 @@ class RatingView: UIView {
             }
         }
     }
-    var fillMode = FillMode.full
+    var fillMode:FillMode = .precise
     var starSize = 20 {
         didSet {
             self.update()
         }
     }
     var starSpacing = 5
-    var updateOnTouch = true
+    var updateOnTouch = false
     var didFinishTouchingCosmos: ((Double) -> Void)?
     var imageKind: RatingImageKind = .star
     private var viewSize = CGSize()
@@ -78,6 +78,9 @@ class RatingView: UIView {
         let layers = self.createStarLayers()
         self.layer.sublayers = layers
         self.updateSize(layers)
+        guard updateOnTouch else { return }
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.impactOccurred()
     }
 
     open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Escaper/Escaper/Presentation/Record/RecordViewController.swift
+++ b/Escaper/Escaper/Presentation/Record/RecordViewController.swift
@@ -123,16 +123,6 @@ class RecordViewController: DefaultViewController {
     }
 }
 
-extension RecordViewController: AddRecordViewControllerDelegate {
-    func addRecordButtonTouched() {
-        // TODO: ViewWillAppear와 두번 호출 문제 발생 
-        //        self.viewModel?.fetch(userEmail: UserSupervisor.shared.email)
-//        if self.recordCollectionView.numberOfItems(inSection: .zero) != .zero {
-//            self.recordCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .left, animated: true)
-//        }
-    }
-}
-
 extension RecordViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return CGFloat(10)
@@ -374,7 +364,7 @@ private extension RecordViewController {
 
     @objc func addButtonTapped() {
         let addRecordViewController = AddRecordViewController()
-        addRecordViewController.create(delegateTarget: self)
+        addRecordViewController.create()
         addRecordViewController.modalPresentationStyle = .fullScreen
         self.present(addRecordViewController, animated: true)
     }

--- a/Escaper/Escaper/Presentation/Record/RecordViewModel.swift
+++ b/Escaper/Escaper/Presentation/Record/RecordViewModel.swift
@@ -33,7 +33,7 @@ final class DefaultRecordViewModel: RecordViewModel {
                 guard !self.records.value.contains(record) else { return }
                 let records = self.records.value + [record]
                 self.records.value = records.sorted(by: { $0.createdTime > $1.createdTime })
-            case .failure(let error):
+            case .failure:
                 self.records.value = []
             }
         }

--- a/Escaper/Escaper/Presentation/Record/Views/Cells/RecordStarView.swift
+++ b/Escaper/Escaper/Presentation/Record/Views/Cells/RecordStarView.swift
@@ -15,8 +15,6 @@ final class RecordStarView: UIView {
     }()
     private let satisfactionRatingView: RatingView = {
         let ratingView = RatingView()
-        ratingView.fillMode = .precise
-        ratingView.updateOnTouch = false
         ratingView.imageKind = .star
         return ratingView
     }()
@@ -27,8 +25,6 @@ final class RecordStarView: UIView {
     }()
     private let difficultyRatingView: RatingView = {
         let ratingView = RatingView()
-        ratingView.fillMode = .precise
-        ratingView.updateOnTouch = false
         ratingView.imageKind = .lock
         return ratingView
     }()

--- a/Escaper/Escaper/Presentation/RoomDetail/Views/InfoDescriptionRatingStackView.swift
+++ b/Escaper/Escaper/Presentation/RoomDetail/Views/InfoDescriptionRatingStackView.swift
@@ -11,9 +11,7 @@ final class InfoDescriptionRatingStackView: UIStackView {
     private var titleLabel: UILabel = EDSLabel.b01B(color: .gloomyPink)
     private var ratingView: RatingView = {
         let rating = RatingView()
-        rating.fillMode = .precise
         rating.currentRating = 0
-        rating.updateOnTouch = false
         return rating
     }()
 

--- a/Escaper/Escaper/Presentation/RoomList/RoomListViewController.swift
+++ b/Escaper/Escaper/Presentation/RoomList/RoomListViewController.swift
@@ -90,7 +90,7 @@ extension RoomListViewController: TagScrollViewDelegate {
     func tagSelected(element: Tagable) {
         switch element {
         case is Genre:
-            guard let district = self.districtSelectButton.selectedDistrict else { return }
+            let district = self.districtSelectButton.selectedDistrict ?? .none
             self.fetchWithCurrentSelectedOption(with: district)
         case let sortingOption as SortingOption:
             self.viewModel?.sort(option: sortingOption)
@@ -284,8 +284,8 @@ private extension RoomListViewController {
         let locale = Locale(identifier: Constant.localeIdentifier)
         geocoder.reverseGeocodeLocation(location, preferredLocale: locale) {  placeMarks, _ in
             guard let address: [CLPlacemark] = placeMarks,
-                  let locality = address.last?.locality,
-                  let district = District.init(rawValue: locality) else { return }
+                  let locality = address.last?.locality else { return }
+            let district = District.init(rawValue: locality) ?? .none
             completion(district)
         }
     }

--- a/Escaper/Escaper/Presentation/RoomList/Views/Cell/RoomOverviewTableViewCell.swift
+++ b/Escaper/Escaper/Presentation/RoomList/Views/Cell/RoomOverviewTableViewCell.swift
@@ -38,7 +38,6 @@ final class RoomOverviewTableViewCell: UITableViewCell {
         self.genreImageView.image = UIImage(named: room.genre.previewImageAssetName)
         self.titleLabel.text = room.title
         self.ratingContainerView.update(difficulty: room.difficulty, satisfaction: room.averageSatisfaction)
-        // TODO: - Measurement 사용하기: Measurement.init(value: room.distance, unit: UnitLength.kilometers)
         self.distanceLabel.text = Helper.measureDistance(room.distance)
         self.accessibilityLabel = "테마 이름 \(room.title), 테마 종류 \(room.genre.name), 난이도 \(room.difficulty)점, 만족도 \(room.averageSatisfaction)점, 거리 " + Helper.measureDistance(room.distance)
         self.accessibilityTraits = .button

--- a/Escaper/Escaper/Presentation/RoomList/Views/DistrictSelectButton.swift
+++ b/Escaper/Escaper/Presentation/RoomList/Views/DistrictSelectButton.swift
@@ -45,6 +45,7 @@ final class DistrictSelectButton: UIButton {
     }
 
     func updateTitle(district: District) {
+        guard district != .none else { return }
         self.districtLabel.text = " \(district.name) "
         self.selectedDistrict = district
         self.infoLabel.text = "기준 "

--- a/Escaper/Escaper/Presentation/RoomList/Views/RatingContainerView.swift
+++ b/Escaper/Escaper/Presentation/RoomList/Views/RatingContainerView.swift
@@ -12,20 +12,16 @@ final class RatingContainerView: UIView {
     private let satisfactionLabel = EDSLabel.b03R(text: "만족도", color: .skullWhite)
     private let difficultyRatingView: RatingView = {
         let rating = RatingView()
-        rating.fillMode = .precise
         rating.currentRating = 0
         rating.starSpacing = 2
         rating.imageKind = .lock
-        rating.updateOnTouch = false
         return rating
     }()
     private let satisfactionRatingView: RatingView = {
         let rating = RatingView()
-        rating.fillMode = .precise
         rating.currentRating = 0
         rating.starSpacing = 2
         rating.imageKind = .star
-        rating.updateOnTouch = false
         return rating
     }()
     override init(frame: CGRect) {

--- a/Escaper/Escaper/Resources/hongdae.json
+++ b/Escaper/Escaper/Resources/hongdae.json
@@ -39,7 +39,7 @@
       "storeName": "비트포비아 홍대던전",
       "telephone": "02-322-4997",
       "homepage": "https://www.xphobia.net/",
-      "address": "서울 마포구 서교동 396-46",
+      "address": "서울특별시 마포구 독막로3길 30",
       "rooms": [
         {
           "title": "날씨의 신",
@@ -267,7 +267,7 @@
       "storeName": "서울이스케이프룸 홍대2호점",
       "telephone": "02-333-6502",
       "homepage": "http://www.seoul-escape.com/",
-      "address": "서울 마포구 서교동 410-9",
+      "address": "서울특별시 마포구 와우산로17길 11",
       "rooms": [
         {
           "title": "CIA본부에서의 탈출",
@@ -567,7 +567,7 @@
           "storeName": "미스터리룸 이스케이프 홍대2호점",
           "telephone": "02-336-9010",
           "homepage": "http://www.mysteryroomescape.com/",
-          "address": "서울 마포구 서교동 398-1",
+          "address": "서울특별시 마포구 독막로7길 41",
           "rooms": [
             {
               "title": "쇼생크 탈출",
@@ -761,7 +761,7 @@
           "storeName": "큐브 이스케이프 홍대점",
           "telephone": "02-323-5567",
           "homepage": "http://cubeescape.co.kr/",
-          "address": "서울 마포구 서교동 355-15",
+          "address": "서울특별시 마포구 양화로16길 15",
           "rooms": [
             {
               "title": "피라미드의 비밀",
@@ -894,7 +894,7 @@
           "storeName": "더큐 이스케이프 홍대입구역점",
           "telephone": "02-322-7063",
           "homepage": "http://www.the-qescapehd2.co.kr/default.php",
-          "address": "서울 마포구 동교동 162-3",
+          "address": "서울특별시 마포구 홍익로6길 15",
           "rooms": [
             {
               "title": "외과병동",
@@ -1009,7 +1009,7 @@
           "storeName": "시크릿코드 홍대점",
           "telephone": "02-332-6561",
           "homepage": "http://www.secret-code.co.kr/",
-          "address": "서울 마포구 서교동 331-18",
+          "address": "서울특별시 마포구 어울마당로 144",
           "rooms": [
             {
               "title": "조난자들",
@@ -1291,7 +1291,7 @@
           "storeName": "브레이크아웃 이스케이프 홍대점",
           "telephone": "02-336-3527",
           "homepage": "https://breakoutescapehongik.modoo.at/",
-          "address": "서울 마포구 서교동 338-48",
+          "address": "서울특별시 마포구 와우산로29가길 37",
           "rooms": [
             {
               "title": "호쿠스 1-마술사의 방",

--- a/Escaper/Escaper/Resources/sinlim.json
+++ b/Escaper/Escaper/Resources/sinlim.json
@@ -321,7 +321,7 @@
       "storeName": "코난 이스케이프 구로디지털단지역점",
       "telephone": "02-830-6224",
       "homepage": "http://www.conanescape.kr/main/main.php",
-      "address": "서울 구로구 구로동 1124-54",
+      "address": "서울특별시 구로구 디지털로32나길 17-12",
       "rooms": [
         {
           "title": "미대생의 죽음",


### PR DESCRIPTION
issue number : [#231](../issues/231)
issue number : [#232](../issues/232)
close #231
close #232

### 작업 사항
- 현재 위치가 서울에 속하지 않을 경우 전체 테마 리스트를 보여준다 
- Rating View 너비 Constraints 추가
- 기록 추가시 탈출 실패할 경우 기록추가가 되지 않는 문제 해결
- 기록 추가시 점수 반영 로직 수정
- DB 구주소는 좌표로 변환이 불가능해 신주소로 변경

### 앱스토어 거절 사유
- 회원가입하는 곳이 불분명하다
- 홈화면에서 테마 데이터가 보이지 않는다 보이는 권한을 달라
- 위치 권한 요청시 설명이 부족하다


<img width="730" alt="Screen Shot 2021-12-01 at 12 21 51 PM" src="https://user-images.githubusercontent.com/38883364/144166306-e370e622-d04b-4a80-b4c4-0d9c45e9105d.png">

<img width="705" alt="Screen Shot 2021-12-01 at 12 21 57 PM" src="https://user-images.githubusercontent.com/38883364/144166321-0b41b6f4-aed9-4223-842c-290782b9674d.png">

<img width="713" alt="Screen Shot 2021-12-01 at 12 22 03 PM" src="https://user-images.githubusercontent.com/38883364/144166339-5877023d-bdeb-48ba-a607-d6f97be4d0c5.png">

Location Purpose
1. Check the user's location on the screen (the first tab) and show a list of Escaping room cafes located in the user's district
2. Show current user location to user on map screen (3rd tab)

