### PR TITLE
상세 화면에서 줄거리를 누르면 팝업창이 띄워지도록 구현

### DIFF
--- a/Escaper/Escaper.xcodeproj/project.pbxproj
+++ b/Escaper/Escaper.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		251CA9AD27525C5B00BA5EC5 /* EmptyResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251CA9AC27525C5B00BA5EC5 /* EmptyResultView.swift */; };
 		251CA9B0275643CB00BA5EC5 /* ImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251CA9AF275643CB00BA5EC5 /* ImageUploader.swift */; };
 		3E2604A92752180000E07361 /* ValidateTextFieldState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2604A82752180000E07361 /* ValidateTextFieldState.swift */; };
+		3E90918127563A7100ACDB78 /* RoomDescriptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E90918027563A7100ACDB78 /* RoomDescriptionViewController.swift */; };
 		3EBB5A7E274E35C000715F89 /* InjectionDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25104A452744E90F00DB90BF /* InjectionDTOs.swift */; };
 		3EBB5A7F274E35C000715F89 /* DataInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25104A472744E98F00DB90BF /* DataInjection.swift */; };
 		3EBB5A80274E35C000715F89 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCDDE6B272EE0F00027AAAD /* AppDelegate.swift */; };
@@ -268,6 +269,7 @@
 		3E77D566274C89240042133B /* Validator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validator.swift; sourceTree = "<group>"; };
 		3E77D568274CC1BC0042133B /* DefaultLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLoginViewModel.swift; sourceTree = "<group>"; };
 		3E8A64FC274E20E30005F788 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		3E90918027563A7100ACDB78 /* RoomDescriptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomDescriptionViewController.swift; sourceTree = "<group>"; };
 		3EED222D273CDA150084D290 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -564,6 +566,7 @@
 			children = (
 				0CAEE3A8273A3769002C1136 /* RoomDetailViewController.swift */,
 				0CEE8B332752103300E6C6EA /* RoomDetailViewModel.swift */,
+				3E90918027563A7100ACDB78 /* RoomDescriptionViewController.swift */,
 				0CAEE3AA273A618A002C1136 /* Views */,
 			);
 			path = RoomDetail;
@@ -881,6 +884,7 @@
 				3EBB5A84274E35C000715F89 /* MainTabBarController.swift in Sources */,
 				3EBB5A85274E35C000715F89 /* DefaultViewController.swift in Sources */,
 				3EBB5A87274E35C000715F89 /* LoginViewController.swift in Sources */,
+				3E90918127563A7100ACDB78 /* RoomDescriptionViewController.swift in Sources */,
 				3EBB5A88274E35C000715F89 /* SignUpViewController.swift in Sources */,
 				3EBB5A89274E35C000715F89 /* DefaultLoginViewModel.swift in Sources */,
 				3EBB5A8A274E35C000715F89 /* DefaultSignUpViewModel.swift in Sources */,

--- a/Escaper/Escaper/Presentation/RoomDetail/RoomDescriptionViewController.swift
+++ b/Escaper/Escaper/Presentation/RoomDetail/RoomDescriptionViewController.swift
@@ -1,0 +1,73 @@
+//
+//  RoomDescriptionViewController.swift
+//  Escaper
+//
+//  Created by shinheeRo on 2021/11/30.
+//
+
+import UIKit
+
+class RoomDescriptionViewController: UIViewController {
+    enum Constant {
+        static let fontSize = CGFloat(14)
+        static let verticalSpace = CGFloat(15)
+        static let horizontalSpace = CGFloat(10)
+        static let textSpace = CGFloat(10)
+    }
+
+    private var textView: UITextView = {
+        let view = UITextView()
+        view.layer.cornerRadius = 20
+        view.backgroundColor = EDSColor.gloomyBrown.value
+        view.isScrollEnabled = true
+        view.isEditable = false
+        view.textContainerInset = UIEdgeInsets(top: Constant.verticalSpace, left: Constant.horizontalSpace, bottom: Constant.verticalSpace, right: Constant.horizontalSpace)
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configure()
+        self.configureLayout()
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.dismiss(animated: true, completion: nil)
+    }
+
+    func placeText(text: String) {
+        let range = NSRange(location: 0, length: text.count)
+        let attributedString = NSMutableAttributedString(string: text)
+        attributedString.addAttribute(.foregroundColor, value: EDSColor.skullLightWhite.value as Any, range: range)
+        attributedString.addAttribute(.font, value: UIFont.systemFont(ofSize: Constant.fontSize), range: range)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = Constant.textSpace
+        paragraphStyle.alignment = .justified
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
+        self.textView.attributedText = attributedString
+    }
+
+    func textViewHeight() -> CGFloat {
+        let line = Int(Double(self.textView.text.count*11)/(self.view.frame.size.width*0.9-20))+1
+        let length = Constant.verticalSpace*2 + Constant.fontSize + (Constant.fontSize+Constant.textSpace) * CGFloat(line-1)+5
+        let maxLength = self.view.frame.size.height*0.35
+        return length>maxLength ? maxLength : length
+    }
+}
+
+extension RoomDescriptionViewController {
+    func configure() {
+        self.view.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+    }
+
+    func configureLayout() {
+        self.textView.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(self.textView)
+        NSLayoutConstraint.activate([
+            self.textView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.textView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 0.9),
+            self.textView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+            self.textView.heightAnchor.constraint(equalToConstant: self.textViewHeight())
+        ])
+    }
+}

--- a/Escaper/Escaper/Presentation/RoomDetail/RoomDetailViewController.swift
+++ b/Escaper/Escaper/Presentation/RoomDetail/RoomDetailViewController.swift
@@ -28,6 +28,7 @@ final class RoomDetailViewController: DefaultViewController {
         label.numberOfLines = 4
         label.textAlignment = .center
         label.lineBreakMode = .byTruncatingTail
+        label.isUserInteractionEnabled = true
         return label
     }()
     private let roomDetailInfoView = RoomDetailInfoView()
@@ -57,6 +58,16 @@ final class RoomDetailViewController: DefaultViewController {
     func update(roomId: String) {
         self.viewModel?.fetch(roomId: roomId)
     }
+
+    @objc func descriptionLabelTapped() {
+        let viewController = RoomDescriptionViewController()
+        viewController.modalTransitionStyle = .crossDissolve
+        viewController.modalPresentationStyle = .overFullScreen
+        if let text = self.descriptionLabel.text {
+            viewController.placeText(text: text)
+        }
+        self.present(viewController, animated: true)
+    }
 }
 
 private extension RoomDetailViewController {
@@ -74,6 +85,7 @@ private extension RoomDetailViewController {
     func configure() {
         self.navigationController?.navigationBar.topItem?.title = ""
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: EDSImage.share.value, style: .plain, target: self, action: #selector(self.shareButtonTouched))
+        self.descriptionLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.descriptionLabelTapped)))
     }
 
     func configureLayout() {


### PR DESCRIPTION
### 작업 사항

![](https://i.imgur.com/49ExdsN.png)

- 상세화면에서 줄거리를 누르면 전체 줄거리가 나오는 팝업창이 뜬다.
- 줄거리의 분량에 맞게 팝업창의 세로 길이가 달라진다.
- 줄거리가 너무 길어질 경우에는 일정 크기의 스크롤 가능한 팝업창이 뜨게 된다.
- 팝업창이 띄워진 상태에서 화면을 클릭하면 팝업창이 닫아진다.

![](https://i.imgur.com/l8bOQwo.png)

- 좌측) 줄거리가 긴 팝업창의 예시
- 우측) 팝업창 길이 계산 오류의 예시
    - textView는 텍스트의 line을 property로 제공하지 않아서 개발자가 임의로 계산해야 한다.
    - 그런데 화면에 보여지는 텍스트의 길이와 실제 텍스트의 길이에는 차이가 있다. (모든 텍스트 정렬 방식에서 저마다의 이유로 차이가 생기게 된다.)
    - 그래서 팝업창 길이 계산에는 약간의 오류가 생기게 된다.

