### PR TITLE
리더보드 refresh 애니메이션 추가

### DIFF
--- a/Escaper/Escaper/Presentation/LeaderBoard/LeaderBoardViewController.swift
+++ b/Escaper/Escaper/Presentation/LeaderBoard/LeaderBoardViewController.swift
@@ -103,13 +103,16 @@ private extension LeaderBoardViewController {
 
     func configureRefreshControl() {
         self.refreshControl.addTarget(self, action: #selector(self.refresh(sender:)), for: .valueChanged)
-        self.scrollView.insertSubview(self.refreshControl, at: .zero)
+        self.scrollView.refreshControl = self.refreshControl
     }
 
     func bindViewModel() {
         self.viewModel?.users.observe(on: self, observerBlock: { [weak self] users in
             self?.topRankView.update(users: users.prefix(3).map {$0})
             self?.updateStackView(users: users.prefix(10).map {$0})
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7, execute: { [weak self] in
+                    self?.refreshControl.endRefreshing()
+            })
         })
     }
 
@@ -133,6 +136,5 @@ private extension LeaderBoardViewController {
 
     @objc func refresh(sender: UIRefreshControl) {
         self.update()
-        self.refreshControl.endRefreshing()
     }
 }


### PR DESCRIPTION
![Simulator Screen Recording - iPhone 12 - 2021-12-01 at 23 33 05](https://user-images.githubusercontent.com/48627117/144253234-6c47e739-28b5-4c17-9a7e-e96ce4ef22aa.gif)

## UIRefresh 사용
- viewModel이 데이터를 받고고 0.7초뒤에 indicator가 사라집니다.
- scrollView의 refresh 프로퍼티에 저희가 만든 UIRefresh 인스턴스를 넣습니다.